### PR TITLE
Add classifiers with info about supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ setup(
     url=gh_repo,  # Optional
     author="weaming",  # Optional
     author_email="garden.yuen@gmail.com",  # Optional
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ],
     packages=find_packages(exclude=["contrib", "docs", "tests"]),  # Required
     keywords="abstract json api",  # Optional
     entry_points={},  # Optional

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
     packages=find_packages(exclude=["contrib", "docs", "tests"]),  # Required


### PR DESCRIPTION
It will help those people who will do some version compatability checking with officially recomended tool **caniusepython3** which looks exactly into classifiers to detect that an examined lib supports Python 3.

I think it might especially helpful for those who realized that Python 2 EOL is coming :-)

